### PR TITLE
supolicy: added platform_app to mlstrustedsubject

### DIFF
--- a/Core/template_override/common/post-fs-data.sh
+++ b/Core/template_override/common/post-fs-data.sh
@@ -18,6 +18,7 @@ supolicy --live "allow coredomain coredomain process {execmem}"
 
 # read configs set in our app
 supolicy --live "allow coredomain app_data_file * *"
+supolicy --live "attradd platform_app mlstrustedsubject"
 
 # read module apk file in zygote
 supolicy --live "allow zygote apk_data_file * *"


### PR DESCRIPTION
This allows access of platform apps such as SystemUI to app data files
on devices having SELinux with MLS constrains.

Fixes bug #106 also discussed in #98