### PR TITLE
Perform explicit garbage collection before every backupAndHook

### DIFF
--- a/Bridge/src/main/java/com/elderdrivers/riru/xposed/core/HookMain.java
+++ b/Bridge/src/main/java/com/elderdrivers/riru/xposed/core/HookMain.java
@@ -111,6 +111,7 @@ public class HookMain {
         if (backup != null) {
             HookMethodResolver.resolveMethod(hook, backup);
         }
+        Runtime.getRuntime().gc();
         if (!backupAndHookNative(target, hook, backup)) {
             throw new RuntimeException("Failed to hook " + target + " with " + hook);
         }


### PR DESCRIPTION
Gives GC a chance to do its work before every hook so there is less chance
it gets in the way in the middle of hooking procedure which does critical
memory block operations.
Attempts to fix GC related crashes such as those reported in #127 

Tested by doing several hard as well as soft reboots without getting any runtime crashes so it looks promising at least for my setup where I run rich Xposed module which contains lots of Android core and SystemUI hooks. I ran EdXposed in DEBUG mode and indeed can see garbage collection happening before every hook. E.g.:
```
03-06 08:19:38.946 17675 17675 I zygote64: Explicit concurrent copying GC freed 261(20KB) AllocSpace objects, 0(0B) LOS objects, 62% free, 937KB/2MB, paused 40us total 3.433ms
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: not enough capacity. Allocating...
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: Allocating done
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: target method is at 0x71769328, hook method is at 0x784c1059e0, backup method is at 0x784c1059b8
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: setNonCompilable: access flags is 0x10080002
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: setNonCompilable: access flags is 0x80009
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: origin ep is 0x73503620, new ep is 0x78d4baa000
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: access flags is 0x12080102
03-06 08:19:38.946 17675 17675 I EdXposed-YAHFA: hook and backup done
03-06 08:19:38.947 17675 17675 I EdXposed-YAHFA: methodIndex = 333
```