### PR TITLE
Add Appveyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  ANDROID_HOME: C:\android-sdk-windows
+
+install:
+  - appveyor DownloadFile https://dl.google.com/android/repository/sdk-tools-windows-4333796.zip
+  - 7z x sdk-tools-windows-4333796.zip -oC:\android-sdk-windows > nul
+  - yes | C:\android-sdk-windows\tools\bin\sdkmanager.bat --licenses > nul
+  - C:\android-sdk-windows\tools\bin\sdkmanager.bat "platforms;android-28" > nul
+  - C:\android-sdk-windows\tools\bin\sdkmanager.bat "platform-tools" > nul
+  - C:\android-sdk-windows\tools\bin\sdkmanager.bat "build-tools;28.0.3" > nul
+  - C:\android-sdk-windows\tools\bin\sdkmanager.bat "cmake;3.6.4111459" > nul
+  - C:\android-sdk-windows\tools\bin\sdkmanager.bat "patcher;v4" > nul
+  - C:\android-sdk-windows\tools\bin\sdkmanager.bat "ndk-bundle" > nul
+  - set PATH=%PATH%;C:\android-sdk-windows\ndk-bundle;C:\android-sdk-windows\build-tools\28.0.3
+
+build_script:
+  - gradlew.bat :edxp-core:zipYahfaRelease
+  - gradlew.bat :edxp-core:zipSandhookRelease
+
+artifacts:
+  - path: 'edxp-core\release\**\*.zip'


### PR DESCRIPTION
This pull request adds [Appveyor](https://www.appveyor.com/) support.

Appveyor compiles every commit and adds a checkmark to the commit if it succeeded. It also checks if PRs build properly.
Build artifacts are also made available through the Appveyor site.

After merging;
1. Login at https://www.appveyor.com/ as ElderDrivers.
2. Add EdXposed project.
3. Done.

In Appveyor at your project settings, you can find "badges" like the one below to add to your readme.

[![Build status](https://ci.appveyor.com/api/projects/status/f0potfmxmgrsgp21?svg=true)](https://ci.appveyor.com/project/AeonLucid/edxposed)