### PR TITLE
Fix appveyor yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,4 @@ only_commits:
     - gradle.properties
     - appveyor.yml
 
-version: '0.4.4.4_alpha (4441)'
+version: '0.4.4.4_alpha (4441) {build}'


### PR DESCRIPTION
Setting the version to something static is not preferred by Appveyor.
Example: https://ci.appveyor.com/project/ElderDrivers/edxposed/builds/25296493
Make sure to include `{build}` in the version, which is an auto increment set by Appveyor.
See https://www.appveyor.com/docs/appveyor-yml/ more examples.

If you want, I could also change this pr so the `version` set in Appveyor is actually used in the gradle build process and also `{build}` for `versionCode`. You can manually change the current build number, so its easy to put it above 4441.