### PR TITLE
Add Appveyor versioning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+version: '0.4.4.5_alpha ({build})'
+
 environment:
   ANDROID_HOME: C:\android-sdk-windows
 
@@ -20,6 +22,9 @@ build_script:
 artifacts:
   - path: 'edxp-core\release\**\*.zip'
 
+pull_requests:
+  do_not_increment_build_number: true
+
 only_commits:
   files:
     - dalvikdx/
@@ -35,5 +40,3 @@ only_commits:
     - settings.gradle
     - gradle.properties
     - appveyor.yml
-
-version: '0.4.4.5_alpha (4450) {build}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.4.4.{build}_alpha'
+version: '0.4.4.5_alpha({build})'
 
 environment:
   ANDROID_HOME: C:\android-sdk-windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.4.4.5_alpha ({build})'
+version: '0.4.4.{build}_alpha'
 
 environment:
   ANDROID_HOME: C:\android-sdk-windows

--- a/edxp-core/build.gradle
+++ b/edxp-core/build.gradle
@@ -3,10 +3,24 @@ import org.gradle.internal.os.OperatingSystem
 
 apply plugin: 'com.android.library'
 
-version "v0.4.4.5_alpha"
+// Values set here will be overriden by AppVeyor, feel free to modify during development.
+def buildVersionName = 'v1.0.0'
+def buildVersionCode = 1
+
+if (System.env.APPVEYOR_BUILD_VERSION != null) {
+    buildVersionName = "v${System.getenv('appveyor_build_version')}"
+}
+
+if (System.env.APPVEYOR_BUILD_NUMBER != null) {
+    // Split is necessary because PRs set the build number to "1234-something".
+    def parts = System.env.APPVEYOR_BUILD_NUMBER.split('-')
+    buildVersionCode = Integer.valueOf(parts[0])
+}
+
+version buildVersionName
 
 ext {
-    versionCode = "4450"
+    versionCode = buildVersionCode
     module_name = "EdXposed"
     jar_dest_dir = "${projectDir}/template_override/system/framework/"
     is_windows = OperatingSystem.current().isWindows()
@@ -145,6 +159,14 @@ afterEvaluate {
                     copy {
                         from "${projectDir}/template_override"
                         into zipPathMagiskRelease
+                    }
+                    copy {
+                        from "${projectDir}/template_override/common/util_functions.sh"
+                        into "${zipPathMagiskRelease}/common"
+                        filter { line -> line
+                                .replaceAll('%VERSION%', "$version")
+                                .replaceAll('%VERSION_CODE%', "$versionCode")
+                                .replaceAll('%BACKEND%', "$backendCapped") }
                     }
                     copy {
                         from 'template_override/riru_module.prop'

--- a/edxp-core/build.gradle
+++ b/edxp-core/build.gradle
@@ -144,7 +144,7 @@ afterEvaluate {
                         into templateRootPath
                         rename "module.prop.tpl", "module.prop"
                         expand(moduleId: "$magiskModuleId", backend: "$backendCapped",
-                                versionName: "$version" + "($backend)",
+                                versionName: "$version" + " ($backend)",
                                 versionCode: "$versionCode", authorList: "$authorList")
                         filter(FixCrLfFilter.class, eol: FixCrLfFilter.CrLf.newInstance("lf"))
                     }

--- a/edxp-core/template_override/common/util_functions.sh
+++ b/edxp-core/template_override/common/util_functions.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 
-EDXP_VERSION="0.4.4.5_alpha (4450)"
+EDXP_VERSION="%VERSION% (%VERSION_CODE%) - %BACKEND%"
 ANDROID_SDK=`getprop ro.build.version.sdk`
 BUILD_DESC=`getprop ro.build.description`
 PRODUCT=`getprop ro.build.product`

--- a/edxp-core/template_override/common/util_functions.sh
+++ b/edxp-core/template_override/common/util_functions.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 
-EDXP_VERSION="%VERSION% (%VERSION_CODE%) - %BACKEND%"
+EDXP_VERSION="%VERSION% (%BACKEND%)"
 ANDROID_SDK=`getprop ro.build.version.sdk`
 BUILD_DESC=`getprop ro.build.description`
 PRODUCT=`getprop ro.build.product`


### PR DESCRIPTION
This adds Appveyor versioning as proposed in https://github.com/ElderDrivers/EdXposed/pull/296.
After merging this you should change `Next build number` in Appveyor project settings to something higher than the current `versionCode`.

Also, with this pull request you don't have to modify 3 files anymore for every new version, only `appveyor.yml`. `versionCode` is increased automatically but the `versionName` requires manual modification in the `appveyor.yml` file.

I have also improved the version format when building with AppVeyor. (See `appveyor.yml` for more info)
Gradle: `1.0.0.{buildnumber}`
Magisk module.prop: `1.0.0.{buildnumber} ({backend})`
Magisk util_functions.sh: `1.0.0.{buildnumber} ({backend})`

For an example build, see https://ci.appveyor.com/project/AeonLucid/edxposed/builds/25306013.
Let me know if you have any questions.