### PR TITLE
Also log filename when loadFromDiskLocked failed

### DIFF
--- a/xposed-bridge/src/main/java/de/robv/android/xposed/XSharedPreferences.java
+++ b/xposed-bridge/src/main/java/de/robv/android/xposed/XSharedPreferences.java
@@ -128,11 +128,11 @@ public final class XSharedPreferences implements SharedPreferences {
 				map = mMap;
 			}
 		} catch (XmlPullParserException e) {
-			Log.w(TAG, "getSharedPreferences", e);
+			Log.w(TAG, "getSharedPreferences failed for: " + mFilename, e);
 		} catch (FileNotFoundException ignored) {
 			// SharedPreferencesImpl has a canRead() check, so it doesn't log anything in case the file doesn't exist
 		} catch (IOException e) {
-			Log.w(TAG, "getSharedPreferences", e);
+			Log.w(TAG, "getSharedPreferences failed for: " + mFilename, e);
 		} finally {
 			if (result != null && result.stream != null) {
 				try {


### PR DESCRIPTION
This would help to resolve the issue: now the user can look into that file and see what's inside an try to resolve the issue or fixing/cleaning up that file.

As a workaround I created a small [xposed module](https://github.com/binarynoise/LogFailedXSharedPreferences) to achieve this behaviour but doing this directly would be better