### PR TITLE
Keep the log catcher alive.

### DIFF
--- a/edxp-core/template_override/post-fs-data.sh
+++ b/edxp-core/template_override/post-fs-data.sh
@@ -85,6 +85,19 @@ if [[ -f ${DISABLE_VERBOSE_LOG_FILE} ]]; then
     LOG_VERBOSE=false
 fi
 
+# If logcat client is kicked out by klogd server, we'll restart it.
+# However, if it is killed manually or by EdXposed Manager, we'll exit.
+# Refer to https://github.com/ElderDrivers/EdXposed/pull/575 for more information.
+loop_logcat() {
+    while true
+    do
+        logcat $*
+        if [[ $? -ne 1 ]]; then
+            break
+        fi
+    done
+}
+
 start_log_cather () {
     LOG_FILE_NAME=$1
     LOG_TAG_FILTERS=$2
@@ -126,7 +139,7 @@ start_log_cather () {
     echo "Riru version: ${RIRU_VERSION} (${RIRU_VERCODE})">>${LOG_FILE}
     echo "Riru api: ${RIRU_APICODE}">>${LOG_FILE}
     echo "Magisk: ${MAGISK_VERSION%:*} (${MAGISK_VERCODE})">>${LOG_FILE}
-    logcat -f ${LOG_FILE} *:S ${LOG_TAG_FILTERS} &
+    loop_logcat -f ${LOG_FILE} *:S ${LOG_TAG_FILTERS} &
     LOG_PID=$!
     echo "${LOG_PID}">"${LOG_PATH}/${LOG_FILE_NAME}.pid"
 }


### PR DESCRIPTION
When the Android's log daemon (`logd`) finds there are too many log records and some log reader (`logcat`) does not read them out in time, the reader may be kicked out. Therefore, the logcat can exit unexpectedly with a return code 1 and complains `read: Unexpected EOF` in standard error stream (`stderr`).

Refer to the AOSP's code for details: [logcat/logcat.cpp#1161](https://android.googlesource.com/platform/system/core/+/7382be402a8cdb36344dd55ef70b50ece133ea28/logcat/logcat.cpp#1161), [logd/SimpleLogBuffer.cpp#345](https://android.googlesource.com/platform/system/core/+/7382be402a8cdb36344dd55ef70b50ece133ea28/logd/SimpleLogBuffer.cpp#345).

The module log (`error.log`) and verbose log (`all.log`) of EdXposed are generated by two background logcat processes. So when a logcat process dies, EdXposed's log is also incomplete.

A way to solve the problem is to increase logd's buffer size (by `logcat -G XXX` or in Developer Options). But I think the buffer size is the user's choice.  EdXposed's log system should work regardless of the user-specified log buffer size. (It is allowed to miss some logs if the buffer size is too small.)

So I think it is a good choice to restart the logcat process once it is kicked out. However, if the logcat process is killed manually or by EdXposed Manager, it should not be restarted.

Since the method to kill the log catcher is changed, some changes are needed to be applied in EdXposed Manager. Check it in [this pull request](https://github.com/ElderDrivers/EdXposedManager/pull/107).