### PR TITLE
Don't use sandhook on x86 devices

### DIFF
--- a/edxp-core/src/main/cpp/main/include/config.h
+++ b/edxp-core/src/main/cpp/main/include/config.h
@@ -32,6 +32,7 @@ namespace edxp {
     static constexpr auto kLibFwName = "libandroidfw.so";
     static constexpr auto kLibWhaleName = "libwhale.edxp.so";
     static constexpr auto kLibSandHookName = "libsandhook.edxp.so";
+    static constexpr auto kLibDlName = "libdl.so";
     static constexpr auto kLibSandHookNativeName = "libsandhook-native.so";
 
     static const auto kLibBasePath = std::string(
@@ -41,6 +42,7 @@ namespace edxp {
             LP_SELECT("/apex/com.android.runtime/bin/linker",
                       "/apex/com.android.runtime/bin/linker64"));
 
+    static const auto kLibDlPath = kLibBasePath + kLibDlName;
     static const auto kLibArtLegacyPath = kLibBasePath + kLibArtName;
     static const auto kLibWhalePath = kLibBasePath + kLibWhaleName;
     static const auto kLibSandHookPath = kLibBasePath + kLibSandHookName;

--- a/edxp-core/src/main/cpp/main/src/native_hook.cpp
+++ b/edxp-core/src/main/cpp/main/src/native_hook.cpp
@@ -70,7 +70,13 @@ namespace edxp {
         hook_func = reinterpret_cast<HookFunType>(hook_func_symbol);
 
         if (api_level >= __ANDROID_API_Q__) {
+#if defined(__i386__) || defined(__x86_64__)
+            ScopedDlHandle dl_handle(kLibDlPath.c_str());
+            void *handle = dl_handle.Get();
+            HOOK_FUNC(mydlopen, "__loader_dlopen");
+#else
             InstallLinkerHooks(kLinkerPath.c_str());
+#endif
         } else {
             ScopedDlHandle art_handle(kLibArtLegacyPath.c_str());
             InstallArtHooks(art_handle.Get());


### PR DESCRIPTION
Fix #598 .

Tested on Android Q and Android R emulators.

In Android Q, it needs to follow https://github.com/ElderDrivers/EdXposed/issues/572#issuecomment-673390002 .

In Android R, it needs to ` setenforce 0`