### PR TITLE
Fix false negative when checking for installed EdXposed manager app.

### DIFF
--- a/edxp-core/template_override/post-fs-data.sh
+++ b/edxp-core/template_override/post-fs-data.sh
@@ -152,7 +152,7 @@ cp -f "/system/bin/app_process32" "${MODDIR}/system/bin/app_process32"
 [[ -f "/system/bin/app_process64" ]] && cp -f "/system/bin/app_process64" "${MODDIR}/system/bin/app_process64"
 
 # install stub if manager not installed
-if [[ "$(pm path org.meowcat.edxposed.manager)" == "" && "$(pm path de.robv.android.xposed.installer)" == "" ]]; then
+if [[ "$(pm path org.meowcat.edxposed.manager 2>&1)" == "" && "$(pm path de.robv.android.xposed.installer 2>&1)" == "" ]]; then
     NO_MANAGER=true
 fi
 if [[ ${NO_MANAGER} == true ]]; then


### PR DESCRIPTION
The command `pm path <package name>` fails on some devices, because the
package service isn't yet running at this stage of the boot. In such a
case, the command outputs the following to stderr:

  `cmd: Can't find service: package`

The `post-fs-data.sh` script tests only the output to stdout, however,
which in this case is null, and therefore wrongly concludes that the
EdXposed manager app isn't installed.

If the device in question is running a kernel in SELinux Enforcing mode,
`post-fs-data.sh` will now attempt to place the kernel in Permissive mode,
so that the manager app can be automatically installed.

Unfortunately, on some 2020 Snapdragon-based Samsung devices, such as
the Z Fold2 5G (F916B) and the Tab S7+ 5G (T976B), `setenforce 0` will
hang the stock kernel, triggering a reboot and thereby causing a
bootloop.

This patch ensures that both stdout and stderr are captured when
`pm path ...` is run, so that installation of the manager app is
subsequently attempted only when the command has successfully run and
returned a null string.

This fix has the pleasant side-effect of allowing 2020 Snapdragon-based
Samsung devices to boot from a stock kernel with the EdXposed module
enabled.

This fixes https://github.com/ElderDrivers/EdXposed/issues/601