### PR TITLE
Optimized preference file changes detection mechanism

### DIFF
--- a/xposed-bridge/build.gradle
+++ b/xposed-bridge/build.gradle
@@ -19,9 +19,11 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField "int", "API_CODE", "$apiCode"
+            buildConfigField "boolean", "DEBUG", "false"
         }
         debug {
             buildConfigField "int", "API_CODE", "$apiCode"
+            buildConfigField "boolean", "DEBUG", "true"
         }
     }
 }

--- a/xposed-bridge/src/main/java/de/robv/android/xposed/XSharedPreferences.java
+++ b/xposed-bridge/src/main/java/de/robv/android/xposed/XSharedPreferences.java
@@ -483,6 +483,9 @@ public final class XSharedPreferences implements SharedPreferences {
     @Deprecated
     @Override
     public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+        if (!mWatcherEnabled)
+            throw new UnsupportedOperationException("File watcher feature is disabled for this instance");
+
         synchronized(this) {
             mListeners.put(listener, sContent);
         }
@@ -491,6 +494,9 @@ public final class XSharedPreferences implements SharedPreferences {
     @Deprecated
     @Override
     public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+        if (!mWatcherEnabled)
+            throw new UnsupportedOperationException("File watcher feature is disabled for this instance");
+
         synchronized(this) {
             mListeners.remove(listener);
         }


### PR DESCRIPTION
Optimizations on top of original idea by @XspeedPL.

- introduced new manifest parameter: xposedsharedprefswatcher
- file watcher daemon starts only in case there is at least one module in the hooked process that requested file watcher feature either by specification in the
manifest or using new constructor XSharedPreferences(file, enableWatcher)
- XSharedPreferences instance registers watcher events only when it has support for watcher enabled so even if watcher daemon is already running
due to request by other module, it won't watch for events on files that belong to XSharedPreferences instance that has watcher disabled
- reduced log ouput in case of release builds